### PR TITLE
Add home page and generate favicon to resolve 404 errors

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,24 @@
+import { ImageResponse } from 'next/og';
+
+export const size = {
+  width: 32,
+  height: 32,
+};
+
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          background: 'black',
+        }}
+      />
+    ),
+    size
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,10 @@
+export default function Home() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-4">
+      <h1 className="text-4xl font-bold mb-4">MockMSP</h1>
+      <p className="text-lg text-center max-w-md">
+        This is a demo site for proof of concept — not a real managed service provider.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Create a basic home page at the root of the app
- Dynamically generate a favicon so browsers no longer request a missing icon

## Testing
- `npm run build`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb01d060c08327b2249099f4ec2ea3