### PR TITLE
Improve navigation anchors and layout spacing

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased scroll-smooth`}
       >
         {children}
       </body>

--- a/src/components/pages/about-page.tsx
+++ b/src/components/pages/about-page.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { motion } from "framer-motion";
 
 import { SiteHeader } from "@/components/site-header";
@@ -30,6 +31,8 @@ const stagger = { animate: { transition: { staggerChildren: 0.08 } } };
 const missionIcons = [ShieldCheck, BarChart3, Users] as const;
 const valueIcons = [ShieldCheck, BarChart3, Users, Sparkles] as const;
 
+const containerClass = "mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8";
+
 const initialsFor = (name: string) =>
   name
     .split(" ")
@@ -43,16 +46,18 @@ type AboutPageProps = {
   content: AboutCopy;
 };
 
-const resolveHref = (href: string, locale: Locale) => {
-  if (href.startsWith("#")) {
-    return `${locale === "nl" ? "/nl" : ""}${href}`;
-  }
-  return href;
-};
-
 export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
+  const pathname = usePathname();
+  const homePath = locale === "nl" ? "/nl" : "/";
+  const resolveHref = (href: string) => {
+    if (href.startsWith("#")) {
+      return pathname === homePath ? href : `${homePath}${href}`;
+    }
+    return href;
+  };
+
   return (
-    <div className="min-h-screen bg-white text-slate-900" lang={locale}>
+    <div className="flex min-h-screen flex-col bg-white text-slate-900" lang={locale}>
       <a
         href="#main"
         className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
@@ -61,13 +66,13 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
       </a>
       <SiteHeader locale={locale} copy={header} />
 
-      <main id="main" className="pb-24">
+      <main id="main" className="flex-1 pb-24">
         <section className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-sky-950 to-emerald-950 py-20 text-white">
           <div className="absolute inset-0 -z-10">
             <div className="absolute left-1/4 top-10 h-72 w-72 rounded-full bg-teal-400/20 blur-3xl" />
             <div className="absolute -bottom-20 right-10 h-80 w-80 rounded-full bg-sky-400/20 blur-3xl" />
           </div>
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <motion.div initial="initial" animate="animate" variants={stagger} className="grid gap-12 lg:grid-cols-[1.2fr_1fr]">
               <motion.div variants={fadeUp} className="space-y-6">
                 <div className="inline-flex items-center gap-2 rounded-full bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-200">
@@ -82,13 +87,13 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
                 </div>
                 <div className="flex flex-wrap items-center gap-4">
                   <Button className="rounded-full bg-white/90 px-6 py-2 text-slate-900 hover:bg-white" asChild>
-                    <Link href={resolveHref(content.hero.primaryCta.href, locale)}>
+                    <Link href={resolveHref(content.hero.primaryCta.href)}>
                       {content.hero.primaryCta.label}
                       <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
                     </Link>
                   </Button>
                   <Button variant="secondary" className="rounded-full border-white/60 bg-white/10 text-white hover:bg-white/20" asChild>
-                    <Link href={content.hero.secondaryCta.href}>{content.hero.secondaryCta.label}</Link>
+                    <Link href={resolveHref(content.hero.secondaryCta.href)}>{content.hero.secondaryCta.label}</Link>
                   </Button>
                 </div>
               </motion.div>
@@ -108,7 +113,7 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
         </section>
 
         <section className="-mt-16 pb-20">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <Card className="rounded-3xl border border-slate-200/70 bg-white/80 shadow-xl">
               <CardContent className="grid gap-10 p-8 lg:grid-cols-[1.2fr_1fr]">
                 <div className="space-y-4">
@@ -151,7 +156,7 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
         </section>
 
         <section className="pb-20">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="space-y-3 text-center">
               <h2 className="text-2xl font-semibold text-slate-900">{content.timeline.title}</h2>
             </div>
@@ -169,7 +174,7 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
         </section>
 
         <section className="pb-20">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="space-y-3 text-center">
               <h2 className="text-2xl font-semibold text-slate-900">{content.values.title}</h2>
             </div>
@@ -193,14 +198,14 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
         </section>
 
         <section className="pb-20">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
               <div className="space-y-3">
                 <h2 className="text-2xl font-semibold text-slate-900">{content.team.title}</h2>
                 <p className="text-sm text-slate-600 leading-relaxed">{content.team.description}</p>
               </div>
               <Button variant="outline" className="rounded-full border-slate-200" asChild>
-                <Link href={resolveHref(content.hero.primaryCta.href, locale)}>{content.hero.primaryCta.label}</Link>
+                <Link href={resolveHref(content.hero.primaryCta.href)}>{content.hero.primaryCta.label}</Link>
               </Button>
             </div>
             <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -228,8 +233,8 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
           </div>
         </section>
 
-        <section id="contact" className="pb-12">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="contact" className="pb-12 scroll-mt-32">
+          <div className={containerClass}>
             <Card className="rounded-3xl border border-slate-200/70 bg-gradient-to-br from-slate-900 via-sky-950 to-emerald-900 text-white shadow-xl">
               <CardContent className="flex flex-col gap-8 p-8 md:flex-row md:items-center md:justify-between">
                 <div className="space-y-3">
@@ -245,7 +250,7 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
                   </ul>
                 </div>
                 <Button className="rounded-full bg-white/90 px-6 py-2 text-slate-900 hover:bg-white" asChild>
-                  <Link href={resolveHref(content.closing.cta.href, locale)}>{content.closing.cta.label}</Link>
+                  <Link href={resolveHref(content.closing.cta.href)}>{content.closing.cta.label}</Link>
                 </Button>
               </CardContent>
             </Card>
@@ -253,7 +258,7 @@ export function AboutPage({ locale, header, footer, content }: AboutPageProps) {
         </section>
       </main>
 
-      <SiteFooter copy={footer} />
+      <SiteFooter locale={locale} copy={footer} />
     </div>
   );
 }

--- a/src/components/pages/home-page.tsx
+++ b/src/components/pages/home-page.tsx
@@ -68,6 +68,9 @@ const contactIconFor = (label: string) => {
   return MessageSquare;
 };
 
+const containerClass = "mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8";
+const contactContainerClass = "mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8";
+
 type HomePageProps = {
   locale: Locale;
   header: HeaderCopy;
@@ -77,7 +80,7 @@ type HomePageProps = {
 
 export function HomePage({ locale, header, footer, content }: HomePageProps) {
   return (
-    <div className="min-h-screen bg-white text-slate-900" lang={locale}>
+    <div className="flex min-h-screen flex-col bg-white text-slate-900" lang={locale}>
       <a
         href="#main"
         className="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"
@@ -86,14 +89,14 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
       </a>
       <SiteHeader locale={locale} copy={header} />
 
-      <main id="main">
+      <main id="main" className="flex-1">
         <section className="relative overflow-hidden pb-20 pt-14 sm:pt-20">
           <div className="absolute inset-0 -z-10">
             <div className="absolute -top-32 -left-32 h-64 w-64 rounded-full bg-teal-200/50 blur-3xl" />
             <div className="absolute top-20 -right-28 h-80 w-80 rounded-full bg-sky-200/50 blur-3xl" />
             <div className="absolute bottom-[-120px] left-1/3 h-72 w-72 rounded-full bg-emerald-200/40 blur-3xl" />
           </div>
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <motion.div initial="initial" animate="animate" variants={stagger} className="grid gap-16 lg:grid-cols-[1.45fr_1fr]">
               <motion.div variants={fadeUp} className="space-y-6">
                 <div className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-teal-600/10 via-sky-600/10 to-emerald-500/10 px-4 py-1 text-xs font-semibold text-slate-700 shadow-sm">
@@ -175,7 +178,7 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
         </section>
 
         <section className="pb-16">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="rounded-3xl border border-slate-200/70 bg-white/80 p-8 shadow-lg">
               <div className="text-center">
                 <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
@@ -199,8 +202,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="outcomes" className="bg-gradient-to-r from-teal-50 via-white to-emerald-50 py-16">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="outcomes" className="bg-gradient-to-r from-teal-50 via-white to-emerald-50 py-16 scroll-mt-32">
+          <div className={containerClass}>
             <div className="mx-auto grid gap-6 text-center sm:max-w-3xl">
               <h2 className="text-2xl font-semibold text-slate-900">{content.outcomes.title}</h2>
               <p className="text-slate-600">{content.outcomes.description}</p>
@@ -218,8 +221,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="services" className="py-20">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="services" className="py-20 scroll-mt-32">
+          <div className={containerClass}>
             <div className="md:flex md:items-end md:justify-between">
               <div className="max-w-3xl space-y-3">
                 <h2 className="text-3xl font-semibold text-slate-900">{content.services.title}</h2>
@@ -269,7 +272,7 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
         </section>
 
         <section className="py-20">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="grid gap-8 lg:grid-cols-[1.1fr_1fr]">
               <div className="space-y-4">
                 <h2 className="text-2xl font-semibold text-slate-900">{content.accelerators.title}</h2>
@@ -320,8 +323,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="industries" className="border-y border-slate-200/70 bg-white py-20">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="industries" className="border-y border-slate-200/70 bg-white py-20 scroll-mt-32">
+          <div className={containerClass}>
             <div className="space-y-4 text-center">
               <h2 className="text-2xl font-semibold text-slate-900">{content.industries.title}</h2>
               <p className="text-slate-600">{content.industries.description}</p>
@@ -338,8 +341,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="process" className="py-20">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="process" className="py-20 scroll-mt-32">
+          <div className={containerClass}>
             <div className="grid gap-8 lg:grid-cols-[1fr_1.2fr]">
               <div className="space-y-4">
                 <h2 className="text-2xl font-semibold text-slate-900">{content.process.title}</h2>
@@ -361,7 +364,7 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
         </section>
 
         <section className="bg-gradient-to-br from-slate-900 via-sky-950 to-emerald-950 py-20 text-white">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className={containerClass}>
             <div className="md:flex md:items-center md:justify-between">
               <div className="max-w-3xl space-y-3">
                 <h2 className="text-2xl font-semibold text-white">{content.testimonials.title}</h2>
@@ -384,8 +387,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="pricing" className="py-20">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="pricing" className="py-20 scroll-mt-32">
+          <div className={containerClass}>
             <div className="mx-auto max-w-3xl space-y-3 text-center">
               <h2 className="text-2xl font-semibold text-slate-900">{content.plans.title}</h2>
               <p className="text-slate-600">{content.plans.description}</p>
@@ -428,7 +431,7 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="faq" className="py-20">
+        <section id="faq" className="py-20 scroll-mt-32">
           <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
             <h2 className="text-2xl font-semibold text-slate-900">{content.faq.title}</h2>
             <Accordion type="single" collapsible className="mt-6 divide-y divide-slate-200 rounded-2xl border border-slate-200/70 bg-white/80 shadow-sm">
@@ -446,8 +449,8 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
           </div>
         </section>
 
-        <section id="contact" className="pb-24">
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <section id="contact" className="pb-24 scroll-mt-32">
+          <div className={contactContainerClass}>
             <Card className="rounded-3xl border border-slate-200/70 bg-white/80 shadow-xl">
               <CardContent className="grid gap-12 p-8 lg:grid-cols-[1fr_1.3fr]">
                 <div className="space-y-4">
@@ -512,7 +515,7 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
         </section>
       </main>
 
-      <SiteFooter copy={footer} />
+      <SiteFooter locale={locale} copy={footer} />
     </div>
   );
 }

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,14 +1,28 @@
-import Link from "next/link";
+"use client";
 
-import { FooterCopy } from "@/lib/copy";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { FooterCopy, Locale } from "@/lib/copy";
 
 import { Sparkles, ArrowUpRight } from "lucide-react";
 
 type SiteFooterProps = {
+  locale: Locale;
   copy: FooterCopy;
 };
 
-export function SiteFooter({ copy }: SiteFooterProps) {
+export function SiteFooter({ locale, copy }: SiteFooterProps) {
+  const pathname = usePathname();
+  const homePath = locale === "nl" ? "/nl" : "/";
+  const isOnHome = pathname === homePath;
+  const resolveHref = (href: string) => {
+    if (href.startsWith("#")) {
+      return isOnHome ? href : `${homePath}${href}`;
+    }
+    return href;
+  };
+
   return (
     <footer className="mt-24 bg-gradient-to-br from-slate-900 via-sky-950 to-emerald-950 text-slate-100">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
@@ -35,7 +49,7 @@ export function SiteFooter({ copy }: SiteFooterProps) {
                   {column.links.map((link) => (
                     <li key={link.label}>
                       <Link
-                        href={link.href}
+                        href={resolveHref(link.href)}
                         className="inline-flex items-center gap-1 text-slate-200/90 transition hover:text-white"
                       >
                         <span>{link.label}</span>
@@ -52,7 +66,7 @@ export function SiteFooter({ copy }: SiteFooterProps) {
           <span>© {new Date().getFullYear()} MockMSP. All rights reserved.</span>
           <div className="flex flex-wrap items-center gap-4">
             {copy.legal.map((item) => (
-              <Link key={item.label} href={item.href} className="hover:text-white">
+              <Link key={item.label} href={resolveHref(item.href)} className="hover:text-white">
                 {item.label}
               </Link>
             ))}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -18,6 +18,18 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
   const [open, setOpen] = React.useState(false);
   const pathname = usePathname();
 
+  const homePath = locale === "nl" ? "/nl" : "/";
+  const isOnHome = pathname === homePath;
+  const resolveHref = React.useCallback(
+    (href: string) => {
+      if (href.startsWith("#")) {
+        return isOnHome ? href : `${homePath}${href}`;
+      }
+      return href;
+    },
+    [homePath, isOnHome],
+  );
+
   const isActive = (href: string) => {
     if (href.startsWith("#")) {
       return false;
@@ -39,7 +51,9 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
             className="h-7 rounded-full bg-white/20 text-white hover:bg-white/30"
             asChild
           >
-            <Link href={copy.announcementCta.href}>{copy.announcementCta.label}</Link>
+            <Link href={resolveHref(copy.announcementCta.href)}>
+              {copy.announcementCta.label}
+            </Link>
           </Button>
         </div>
       </div>
@@ -66,10 +80,11 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
               {copy.nav.map((link) => (
                 <Link
                   key={link.label}
-                  href={link.href}
+                  href={resolveHref(link.href)}
                   className={`transition-colors hover:text-slate-900 ${
                     isActive(link.href) ? "text-slate-900" : ""
                   }`}
+                  aria-current={isActive(link.href) ? "page" : undefined}
                 >
                   {link.label}
                 </Link>
@@ -84,10 +99,14 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
                 {copy.languageToggle.label}
               </Link>
               <Button variant="outline" className="rounded-full border-slate-200" asChild>
-                <Link href={copy.secondaryAction.href}>{copy.secondaryAction.label}</Link>
+                <Link href={resolveHref(copy.secondaryAction.href)}>
+                  {copy.secondaryAction.label}
+                </Link>
               </Button>
               <Button className="rounded-full" asChild>
-                <Link href={copy.primaryAction.href}>{copy.primaryAction.label}</Link>
+                <Link href={resolveHref(copy.primaryAction.href)}>
+                  {copy.primaryAction.label}
+                </Link>
               </Button>
             </div>
             <button
@@ -105,8 +124,9 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
               {copy.nav.map((link) => (
                 <Link
                   key={link.label}
-                  href={link.href}
+                  href={resolveHref(link.href)}
                   className="block rounded-xl px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                  aria-current={isActive(link.href) ? "page" : undefined}
                   onClick={() => setOpen(false)}
                 >
                   {link.label}
@@ -122,12 +142,12 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
                   {copy.languageToggle.label}
                 </Link>
                 <Button variant="outline" className="rounded-full border-slate-200 flex-1" asChild>
-                  <Link href={copy.secondaryAction.href} onClick={() => setOpen(false)}>
+                  <Link href={resolveHref(copy.secondaryAction.href)} onClick={() => setOpen(false)}>
                     {copy.secondaryAction.label}
                   </Link>
                 </Button>
                 <Button className="rounded-full flex-1" asChild>
-                  <Link href={copy.primaryAction.href} onClick={() => setOpen(false)}>
+                  <Link href={resolveHref(copy.primaryAction.href)} onClick={() => setOpen(false)}>
                     {copy.primaryAction.label}
                   </Link>
                 </Button>


### PR DESCRIPTION
## Summary
- resolve locale-aware anchor targets in the header and footer so navigation buttons work from any route
- refactor the home and about pages with shared container classes, scroll offsets, and flex layout for consistent spacing
- enable smooth scrolling at the document level for a more polished jump-to-section experience

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d1621988248327a477e3b2e49f0bc2