### PR TITLE
Enhance focus-visible styling on navigation elements

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -50,7 +50,7 @@ export function SiteFooter({ locale, copy }: SiteFooterProps) {
                     <li key={link.label}>
                       <Link
                         href={resolveHref(link.href)}
-                        className="inline-flex items-center gap-1 text-slate-200/90 transition hover:text-white"
+                        className="inline-flex items-center gap-1 text-slate-200/90 transition hover:text-white focus-visible:outline-none focus-visible:text-white focus-visible:underline focus-visible:decoration-sky-300 focus-visible:underline-offset-4"
                       >
                         <span>{link.label}</span>
                         <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
@@ -66,7 +66,11 @@ export function SiteFooter({ locale, copy }: SiteFooterProps) {
           <span>© {new Date().getFullYear()} MockMSP. All rights reserved.</span>
           <div className="flex flex-wrap items-center gap-4">
             {copy.legal.map((item) => (
-              <Link key={item.label} href={resolveHref(item.href)} className="hover:text-white">
+              <Link
+                key={item.label}
+                href={resolveHref(item.href)}
+                className="hover:text-white focus-visible:outline-none focus-visible:text-white focus-visible:underline focus-visible:decoration-sky-300 focus-visible:underline-offset-4"
+              >
                 {item.label}
               </Link>
             ))}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -48,10 +48,10 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
           <Button
             variant="secondary"
             size="sm"
-            className="h-7 rounded-full bg-white/20 text-white hover:bg-white/30"
+            className="h-7 rounded-full bg-white/20 text-white hover:bg-white/30 focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-sky-900"
             asChild
           >
-            <Link href={resolveHref(copy.announcementCta.href)}>
+            <Link href={resolveHref(copy.announcementCta.href)} className="focus-visible:outline-none">
               {copy.announcementCta.label}
             </Link>
           </Button>
@@ -64,13 +64,16 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
             <div className="flex items-center gap-3">
               <Link
                 href={locale === "nl" ? "/nl" : "/"}
-                className="relative flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-sky-600 via-teal-500 to-emerald-500 text-white shadow-lg"
+                className="relative flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-sky-600 via-teal-500 to-emerald-500 text-white shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 <Sparkles className="h-5 w-5" aria-hidden="true" />
                 <span className="sr-only">MockMSP home</span>
               </Link>
               <div className="flex flex-col">
-                <Link href={locale === "nl" ? "/nl" : "/"} className="font-semibold text-lg tracking-tight text-slate-900">
+                <Link
+                  href={locale === "nl" ? "/nl" : "/"}
+                  className="font-semibold text-lg tracking-tight text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                >
                   MockMSP
                 </Link>
                 <span className="text-xs font-medium text-slate-500">{copy.tagline}</span>
@@ -81,7 +84,7 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
                 <Link
                   key={link.label}
                   href={resolveHref(link.href)}
-                  className={`transition-colors hover:text-slate-900 ${
+                  className={`transition-colors hover:text-slate-900 focus-visible:outline-none focus-visible:text-slate-900 focus-visible:underline focus-visible:decoration-2 focus-visible:underline-offset-4 focus-visible:decoration-sky-500 ${
                     isActive(link.href) ? "text-slate-900" : ""
                   }`}
                   aria-current={isActive(link.href) ? "page" : undefined}
@@ -93,25 +96,31 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
             <div className="hidden md:flex items-center gap-3">
               <Link
                 href={copy.languageToggle.href}
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-sky-200 hover:text-slate-900"
+                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 shadow-sm transition hover:border-sky-200 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 <Languages className="h-3.5 w-3.5" aria-hidden="true" />
                 {copy.languageToggle.label}
               </Link>
               <Button variant="outline" className="rounded-full border-slate-200" asChild>
-                <Link href={resolveHref(copy.secondaryAction.href)}>
+                <Link
+                  href={resolveHref(copy.secondaryAction.href)}
+                  className="focus-visible:outline-none"
+                >
                   {copy.secondaryAction.label}
                 </Link>
               </Button>
               <Button className="rounded-full" asChild>
-                <Link href={resolveHref(copy.primaryAction.href)}>
+                <Link
+                  href={resolveHref(copy.primaryAction.href)}
+                  className="focus-visible:outline-none"
+                >
                   {copy.primaryAction.label}
                 </Link>
               </Button>
             </div>
             <button
               aria-label="Toggle menu"
-              className="md:hidden rounded-xl border border-slate-200 p-2 text-slate-600"
+              className="md:hidden rounded-xl border border-slate-200 p-2 text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               onClick={() => setOpen((value) => !value)}
             >
               {open ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
@@ -125,7 +134,7 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
                 <Link
                   key={link.label}
                   href={resolveHref(link.href)}
-                  className="block rounded-xl px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100"
+                  className="block rounded-xl px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                   aria-current={isActive(link.href) ? "page" : undefined}
                   onClick={() => setOpen(false)}
                 >
@@ -135,7 +144,7 @@ export function SiteHeader({ locale, copy }: SiteHeaderProps) {
               <div className="flex flex-wrap items-center gap-3 pt-2">
                 <Link
                   href={copy.languageToggle.href}
-                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600"
+                  className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white"
                   onClick={() => setOpen(false)}
                 >
                   <Languages className="h-3.5 w-3.5" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- add focus-visible ring and underline styles to site header links and controls
- extend footer links with focus-visible feedback for keyboard navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d657d6db848327b0c394d41663d93f