### PR TITLE
Add accessible labels to contact form

### DIFF
--- a/src/components/pages/home-page.tsx
+++ b/src/components/pages/home-page.tsx
@@ -477,11 +477,20 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
                   }}
                 >
                   {content.contact.fields.map((field) => {
+                    const fieldId = `contact-${field.name}`;
                     const isMessageField = field.name === "challenge";
                     if (isMessageField) {
                       return (
-                        <div key={field.name} className="sm:col-span-2">
+                        <div key={field.name} className="sm:col-span-2 space-y-2">
+                          <label
+                            htmlFor={fieldId}
+                            className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                          >
+                            {field.label}
+                          </label>
                           <textarea
+                            id={fieldId}
+                            name={field.name}
                             required
                             placeholder={field.placeholder}
                             className="w-full rounded-2xl border border-border bg-card px-4 py-3 text-sm text-muted-foreground shadow-inner focus:border-teal-400 focus:outline-none focus:ring-2 focus:ring-teal-100"
@@ -491,13 +500,22 @@ export function HomePage({ locale, header, footer, content }: HomePageProps) {
                       );
                     }
                     return (
-                      <Input
-                        key={field.name}
-                        type={field.type}
-                        required
-                        placeholder={field.placeholder}
-                        className="rounded-2xl border-border bg-card text-sm text-muted-foreground shadow-inner focus:border-teal-400 focus-visible:ring-teal-100"
-                      />
+                      <div key={field.name} className="space-y-2">
+                        <label
+                          htmlFor={fieldId}
+                          className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                        >
+                          {field.label}
+                        </label>
+                        <Input
+                          id={fieldId}
+                          name={field.name}
+                          type={field.type}
+                          required
+                          placeholder={field.placeholder}
+                          className="rounded-2xl border-border bg-card text-sm text-muted-foreground shadow-inner focus:border-teal-400 focus-visible:ring-teal-100"
+                        />
+                      </div>
                     );
                   })}
                   <div className="sm:col-span-2 space-y-3">

--- a/src/lib/copy.ts
+++ b/src/lib/copy.ts
@@ -371,11 +371,12 @@ export const copy = {
         description:
           "Tell us about your Microsoft 365 estate and growth goals. We'll return a tailored plan within two business days.",
         fields: [
-          { name: "name", placeholder: "Full name", type: "text" },
-          { name: "email", placeholder: "Work email", type: "email" },
-          { name: "company", placeholder: "Company", type: "text" },
+          { name: "name", label: "Full name", placeholder: "Full name", type: "text" },
+          { name: "email", label: "Work email", placeholder: "Work email", type: "email" },
+          { name: "company", label: "Company", placeholder: "Company", type: "text" },
           {
             name: "challenge",
+            label: "Current challenge",
             placeholder: "What's your biggest challenge right now?",
             type: "text",
           },
@@ -946,11 +947,12 @@ export const copy = {
         description:
           "Vertel ons over uw Microsoft 365-omgeving en groeidoelen. U ontvangt binnen twee werkdagen een voorstel.",
         fields: [
-          { name: "name", placeholder: "Volledige naam", type: "text" },
-          { name: "email", placeholder: "Zakelijk e-mailadres", type: "email" },
-          { name: "company", placeholder: "Organisatie", type: "text" },
+          { name: "name", label: "Volledige naam", placeholder: "Volledige naam", type: "text" },
+          { name: "email", label: "Zakelijk e-mailadres", placeholder: "Zakelijk e-mailadres", type: "email" },
+          { name: "company", label: "Organisatie", placeholder: "Organisatie", type: "text" },
           {
             name: "challenge",
+            label: "Belangrijkste uitdaging",
             placeholder: "Wat is momenteel uw grootste uitdaging?",
             type: "text",
           },


### PR DESCRIPTION
## Summary
- add human-readable labels to contact field copy for both locales
- render labeled inputs/textareas with matching ids and small caps styling on the home page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65ab5123883278a96558e709bfd42